### PR TITLE
Node layout

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -83,27 +83,40 @@ jobs:
           echo TF_VAR_vm_name=$COMMIT_ID >> env.list
 
       - name: Plan
-        run: |        
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          COMMIT_ID=$(echo $GITHUB_CONTEXT | jq -r '.sha' | cut -c1-7)        
           sudo docker run --rm -v `pwd`/deliverables-$COMMIT_ID:/terraform/vsphere-rancher/deliverables \
             --env-file env.list \
             terraform-rancher:latest plan -input="false"
 
       - name: Deploy
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
+          COMMIT_ID=$(echo $GITHUB_CONTEXT | jq -r '.sha' | cut -c1-7)
           sudo docker run --rm -v `pwd`/deliverables-$COMMIT_ID:/terraform/vsphere-rancher/deliverables \
             --env-file env.list \
             terraform-rancher:latest apply -input="false" -auto-approve
       
       - name: Wait 15 minutes
         if : ${{ failure() }}
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
+          COMMIT_ID=$(echo $GITHUB_CONTEXT | jq -r '.sha' | cut -c1-7)
+          ls `pwd`/deliverables-$COMMIT_ID
           cat `pwd`/deliverables-$COMMIT_ID/kubeconfig
           sleep 15m
           
 
       - name: Destroy
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
         if: ${{ always() }}
         run: |
+          COMMIT_ID=$(echo $GITHUB_CONTEXT | jq -r '.sha' | cut -c1-7)
           sudo docker run --rm -v `pwd`/deliverables-$COMMIT_ID:/terraform/vsphere-rancher/deliverables \
             --env-file env.list \
             terraform-rancher:latest destroy -input="false" -auto-approve

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   validate:
     name: Validate Terraform
-    runs-on: ez-rancher
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -77,7 +77,8 @@ jobs:
           TF_VAR_bootstrap_rancher: true
           TF_VAR_vsphere_resource_pool: ${{ secrets.TF_VSPHERE_RESOURCE_POOL }}
         run: |
-          mkdir deliverables
+          export COMMIT_ID=$(echo $GITHUB_CONTEXT | jq -r '.sha' | cut -c1-7)
+          mkdir deliverables-$COMMIT_ID
           env | grep TF_ > env.list
           export COMMIT_ID=$(echo $GITHUB_CONTEXT | jq -r '.sha' | cut -c1-7)
           echo TF_VAR_vm_name=$COMMIT_ID >> env.list

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -80,7 +80,6 @@ jobs:
           export COMMIT_ID=$(echo $GITHUB_CONTEXT | jq -r '.sha' | cut -c1-7)
           mkdir deliverables-$COMMIT_ID
           env | grep TF_ > env.list
-          export COMMIT_ID=$(echo $GITHUB_CONTEXT | jq -r '.sha' | cut -c1-7)
           echo TF_VAR_vm_name=$COMMIT_ID >> env.list
 
       - name: Plan
@@ -99,18 +98,7 @@ jobs:
           COMMIT_ID=$(echo $GITHUB_CONTEXT | jq -r '.sha' | cut -c1-7)
           sudo docker run --rm -v `pwd`/deliverables-$COMMIT_ID:/terraform/vsphere-rancher/deliverables \
             --env-file env.list \
-            terraform-rancher:latest apply -input="false" -auto-approve
-      
-      - name: Wait 15 minutes
-        if : ${{ failure() }}
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          COMMIT_ID=$(echo $GITHUB_CONTEXT | jq -r '.sha' | cut -c1-7)
-          ls `pwd`/deliverables-$COMMIT_ID
-          cat `pwd`/deliverables-$COMMIT_ID/kubeconfig
-          sleep 15m
-          
+            terraform-rancher:latest apply -input="false" -auto-approve         
 
       - name: Destroy
         env:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -65,25 +65,25 @@ jobs:
         run: |
           mkdir deliverables
           env | grep TF_ > env.list
-          COMMIT_ID=$(echo $GITHUB_CONTEXT | jq -r '.sha' | cut -c1-7)
+          export COMMIT_ID=$(echo $GITHUB_CONTEXT | jq -r '.sha' | cut -c1-7)
           echo TF_VAR_vm_name=$COMMIT_ID >> env.list
 
       - name: Plan
         run: |        
-          sudo docker run --rm -v `pwd`/deliverables:/terraform/vsphere-rancher/deliverables \
+          sudo docker run --rm -v `pwd`/deliverables-$COMMIT_ID:/terraform/vsphere-rancher/deliverables \
             --env-file env.list \
             terraform-rancher:latest plan -input="false"
 
       - name: Deploy
         run: |
-          sudo docker run --rm -v `pwd`/deliverables:/terraform/vsphere-rancher/deliverables \
+          sudo docker run --rm -v `pwd`/deliverables-$COMMIT_ID:/terraform/vsphere-rancher/deliverables \
             --env-file env.list \
             terraform-rancher:latest apply -input="false" -auto-approve
       
       - name: Destroy
         if: ${{ always() }}
         run: |
-          sudo docker run --rm -v `pwd`/deliverables:/terraform/vsphere-rancher/deliverables \
+          sudo docker run --rm -v `pwd`/deliverables-$COMMIT_ID:/terraform/vsphere-rancher/deliverables \
             --env-file env.list \
             terraform-rancher:latest destroy -input="false" -auto-approve
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -6,6 +6,10 @@ on:
     - 'terraform/**'
     - '.github/workflows/workflow.yaml'
   workflow_dispatch:
+    inputs:
+      git-ref:
+        description: Git Ref (Optional)    
+        required: false
   schedule:
     - cron: '45 * * * *'
 
@@ -16,6 +20,13 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        if: github.event.inputs.git-ref == ''
+        
+      - name: Clone Repository (Custom Ref)
+        uses: actions/checkout@v2
+        if: github.event.inputs.git-ref != ''
+        with:
+          ref: ${{ github.event.inputs.git-ref }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -5,6 +5,9 @@ on:
     paths:
     - 'terraform/**'
     - '.github/workflows/workflow.yaml'
+  workflow_dispatch:
+  schedule:
+    - cron: '45 * * * *'
 
 jobs:
   validate:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -35,6 +35,7 @@ jobs:
   docker-deploy:
     name: Docker Deploy - DHCP
     runs-on: docker
+    needs: validate
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,9 +1,6 @@
-name: Terraform Validate and Test
+name: Validate and Deploy
 
 on:
-  pull_request:
-    branches:
-    - main
   push:
     paths:
     - 'terraform/**'
@@ -11,7 +8,7 @@ on:
 
 jobs:
   validate:
-    name: Validate
+    name: Validate Terraform
     runs-on: ez-rancher
     steps:
       - name: Check out code
@@ -35,14 +32,19 @@ jobs:
         run: terraform validate
         working-directory: ./terraform/vsphere-rancher
 
-      - name: Generate SSH Keys
-        run: |
-          rm -f ~/.ssh/id_rsa*
-          ssh-keygen -q -t rsa -N '' -f ~/.ssh/id_rsa
+  docker-deploy:
+    name: Docker Deploy - DHCP
+    runs-on: docker
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      
+      - name: Build image
+        run: sudo docker build -t terraform-rancher:latest .
 
-      - name: Deploy Test Env
-        working-directory: ./terraform/vsphere-rancher
+      - name: Create vars file
         env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
           TF_VAR_control_plane_count: 1
           TF_VAR_worker_count: 2
           TF_VAR_vm_template_name: bionic-server-cloudimg-amd64
@@ -60,29 +62,28 @@ jobs:
           TF_VAR_bootstrap_rancher: true
           TF_VAR_vsphere_resource_pool: ${{ secrets.TF_VSPHERE_RESOURCE_POOL }}
         run: |
-          COMMIT_ID=$(git rev-parse --short HEAD)
-          terraform apply -input="false" -auto-approve -var="vm_name=${COMMIT_ID}"
+          mkdir deliverables
+          env | grep TF_ > env.list
+          COMMIT_ID=$(echo $GITHUB_CONTEXT | jq -r '.sha' | cut -c1-7)
+          echo TF_VAR_vm_name=$COMMIT_ID >> env.list
 
-      - name: Cleanup Test Env
+      - name: Plan
+        run: |        
+          sudo docker run --rm -v `pwd`/deliverables:/terraform/vsphere-rancher/deliverables \
+            --env-file env.list \
+            terraform-rancher:latest plan -input="false"
+
+      - name: Deploy
+        run: |
+          sudo docker run --rm -v `pwd`/deliverables:/terraform/vsphere-rancher/deliverables \
+            --env-file env.list \
+            terraform-rancher:latest apply -input="false" -auto-approve
+      
+      - name: Destroy
         if: ${{ always() }}
-        env:
-          TF_VAR_control_plane_count: 1
-          TF_VAR_worker_count: 2
-          TF_VAR_vm_template_name: bionic-server-cloudimg-amd64
-          TF_VAR_vsphere_vcenter: ${{ secrets.TF_VSPHERE_VCENTER }}
-          TF_VAR_vsphere_user: ${{ secrets.TF_VSPHERE_USER }}
-          TF_VAR_vsphere_password: ${{ secrets.TF_VSPHERE_PASSWORD }}
-          TF_VAR_vsphere_unverified_ssl: true
-          TF_VAR_vsphere_datacenter: ${{ secrets.TF_VSPHERE_DATACENTER }}
-          TF_VAR_vm_datastore: ${{ secrets.TF_VM_DATASTORE }}
-          TF_VAR_vm_network: ${{ secrets.TF_VM_NETWORK }}
-          TF_VAR_vsphere_vm_folder: ${{ secrets.TF_VSPHERE_VM_FOLDER }}
-          TF_VAR_vm_domain: example.net
-          TF_VAR_rancher_server_url: ${{ secrets.TF_RANCHER_SERVER_URL }}
-          TF_VAR_rancher_password: ${{ secrets.TF_RANCHER_PASSWORD }}
-          TF_VAR_bootstrap_rancher: true
-          TF_VAR_vsphere_resource_pool: ${{ secrets.TF_VSPHERE_RESOURCE_POOL }}
-        working-directory: ./terraform/vsphere-rancher
         run: |
-          COMMIT_ID=$(git rev-parse --short HEAD)
-          terraform destroy -input="false" -auto-approve -var="vm_name=${COMMIT_ID}"
+          sudo docker run --rm -v `pwd`/deliverables:/terraform/vsphere-rancher/deliverables \
+            --env-file env.list \
+            terraform-rancher:latest destroy -input="false" -auto-approve
+
+          

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
         if: github.event.inputs.git-ref == ''
-        
+
       - name: Clone Repository (Custom Ref)
         uses: actions/checkout@v2
         if: github.event.inputs.git-ref != ''
@@ -94,6 +94,13 @@ jobs:
             --env-file env.list \
             terraform-rancher:latest apply -input="false" -auto-approve
       
+      - name: Wait 15 minutes
+        if : ${{ failure() }}
+        run: |
+          cat `pwd`/deliverables-$COMMIT_ID/kubeconfig
+          sleep 15m
+          
+
       - name: Destroy
         if: ${{ always() }}
         run: |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ The `rancher_server_url` input must resolve to one of the worker node IPs.
 
 If DHCP is used (default), this can be done after the deployment completes and the worker nodes recieve an IP from the `vm_network`. 
 
+**Supplemental DNS names**
+
+The Rancher service is also accessible via **\<node ip address>.nip.io** for each node in the cluster. This provides additional hostnames that can be used to access the rancher service in the event of a node failure, or simply for convenience.
+
+**DNS and Automatic Bootstrapping**
+
+If `bootstrap_rancher` is enabled, there are special considerations with respect to DNS:
+* If using `static_ip_addresses`, the `rancher_server_url` must resolve to one or more of the cluster nodes.
+* If using DHCP, the `rancher_server_url` will be automatically overridden to **\<ip address of first node>.nip.io**. This is done in order to provide a hostname to access the rancher service for bootstrapping.
+
 ## Getting Started
 For tfvars config file examples, refer to [tfvars examples](docs/TfvarsExamples.md)
 

--- a/rancher.tfvars.example
+++ b/rancher.tfvars.example
@@ -2,12 +2,6 @@
 # VMware VMs configuration #
 # ======================== #
 
-# (Optional) number of control plane nodes in the kubernetes cluster. Defaults to 1
-control_plane_count = "1"
-
-# (Optional) number of worker nodes in the kubernetes cluster. Defaults to 2
-worker_count        = "2"
-
 # Name that all VMs will be prefixed with
 vm_name             = "rancher"
 
@@ -73,7 +67,7 @@ ssh_public_key = "~/.ssh/id_rsa.pub"
 
 # Rancher server URL
 # If bootstrap_rancher is enabled and DHCP is being used for hosts, 
-# this will be automatically overridden to <IP of first worker>.nip.io 
+# this will be automatically overridden to <IP of first node>.nip.io 
 rancher_server_url = "my.rancher.org"
 
 # Automatically configure rancher:

--- a/rancher.tfvars.example
+++ b/rancher.tfvars.example
@@ -73,6 +73,8 @@ rancher_server_url = "my.rancher.org"
 # Automatically configure rancher:
 # - Updates the default admin password, provided by the rancher_password variable.
 # - Enables telemetry 
+# - Creates cloud credentials for vCenter
+# - Creates node template for vCenter
 bootstrap_rancher = false
 
 # rancher default admin password

--- a/terraform/modules/kubernetes/rancher/bootstrap.tf
+++ b/terraform/modules/kubernetes/rancher/bootstrap.tf
@@ -64,6 +64,7 @@ resource "rancher2_node_template" "vsphere" {
     memory_size = var.user_cluster_memoryMB
     datacenter  = var.rancher_vsphere_datacenter
     datastore   = var.rancher_vsphere_datastore
+    disk_size   = var.rancher_node_template_disk_size
     folder      = var.rancher_vsphere_folder
     network     = [var.rancher_vsphere_network]
     pool        = var.rancher_vsphere_pool

--- a/terraform/modules/kubernetes/rancher/main.tf
+++ b/terraform/modules/kubernetes/rancher/main.tf
@@ -94,7 +94,7 @@ resource "helm_release" "rancher" {
 
   set {
     name  = "ingress.extraAnnotations.nginx\\.ingress\\.kubernetes\\.io/server-alias"
-    value = join(",", formatlist("%s.nip.io", [for node in slice(var.cluster_nodes, 1, length(var.cluster_nodes)) : node["ip"]]))
+    value = join(" ", formatlist("%s.nip.io", [for node in slice(var.cluster_nodes, 1, length(var.cluster_nodes)) : node["ip"]]))
   }
 
 }

--- a/terraform/modules/kubernetes/rancher/main.tf
+++ b/terraform/modules/kubernetes/rancher/main.tf
@@ -92,4 +92,9 @@ resource "helm_release" "rancher" {
     value = var.rancher_server_url
   }
 
+  set {
+    name  = "ingress.extraAnnotations.nginx\\.ingress\\.kubernetes\\.io/server-alias"
+    value = join(",", formatlist("%s.nip.io", [for node in slice(var.cluster_nodes, 1, length(var.cluster_nodes)-1): node["ip"]]))
+  }
+
 }

--- a/terraform/modules/kubernetes/rancher/main.tf
+++ b/terraform/modules/kubernetes/rancher/main.tf
@@ -1,5 +1,5 @@
 locals {
-  deliverables_path = var.deliverables_path == "" ? "./deliverables" : var.deliverables_path
+  deliverables_path  = var.deliverables_path == "" ? "./deliverables" : var.deliverables_path
   alias_initial_node = var.rancher_server_url == join("", [var.cluster_nodes[0].ip, ".nip.io"]) ? 1 : 0
 }
 

--- a/terraform/modules/kubernetes/rancher/main.tf
+++ b/terraform/modules/kubernetes/rancher/main.tf
@@ -94,7 +94,7 @@ resource "helm_release" "rancher" {
 
   set {
     name  = "ingress.extraAnnotations.nginx\\.ingress\\.kubernetes\\.io/server-alias"
-    value = join(",", formatlist("%s.nip.io", [for node in slice(var.cluster_nodes, 1, length(var.cluster_nodes) - 1) : node["ip"]]))
+    value = join(",", formatlist("%s.nip.io", [for node in slice(var.cluster_nodes, 1, length(var.cluster_nodes)) : node["ip"]]))
   }
 
 }

--- a/terraform/modules/kubernetes/rancher/main.tf
+++ b/terraform/modules/kubernetes/rancher/main.tf
@@ -75,8 +75,14 @@ resource "helm_release" "cert-manager" {
   }
 }
 
+resource "time_sleep" "wait_for_cert_manager" {
+  depends_on = [helm_release.cert-manager]
+
+  create_duration = "30s"
+}
+
 resource "helm_release" "rancher" {
-  depends_on       = [helm_release.cert-manager]
+  depends_on       = [helm_release.cert-manager, time_sleep.wait_for_cert_manager]
   name             = "rancher"
   chart            = "rancher"
   repository       = "https://releases.rancher.com/server-charts/stable"

--- a/terraform/modules/kubernetes/rancher/main.tf
+++ b/terraform/modules/kubernetes/rancher/main.tf
@@ -1,5 +1,6 @@
 locals {
   deliverables_path = var.deliverables_path == "" ? "./deliverables" : var.deliverables_path
+  alias_initial_node = var.rancher_server_url == join("", [var.cluster_nodes[0].ip, ".nip.io"]) ? 1 : 0
 }
 
 resource "rke_cluster" "cluster" {
@@ -101,7 +102,7 @@ resource "helm_release" "rancher" {
 
   set {
     name  = "ingress.extraAnnotations.nginx\\.ingress\\.kubernetes\\.io/server-alias"
-    value = join(" ", formatlist("%s.nip.io", [for node in slice(var.cluster_nodes, 1, length(var.cluster_nodes)) : node["ip"]]))
+    value = join(" ", formatlist("%s.nip.io", [for node in slice(var.cluster_nodes, local.alias_initial_node, length(var.cluster_nodes)) : node["ip"]]))
   }
 
 }

--- a/terraform/modules/kubernetes/rancher/main.tf
+++ b/terraform/modules/kubernetes/rancher/main.tf
@@ -7,7 +7,7 @@ resource "rke_cluster" "cluster" {
   # 2 minute timeout specifically for rke-network-plugin-deploy-job but will apply to any addons
   addon_job_timeout = 120
   dynamic "nodes" {
-    for_each = [for node in var.control_plane_nodes : {
+    for_each = [for node in var.cluster_nodes : {
       name = node["name"]
       ip   = node["ip"]
     }]
@@ -15,21 +15,7 @@ resource "rke_cluster" "cluster" {
       address           = nodes.value.ip
       hostname_override = nodes.value.name
       user              = "ubuntu"
-      role              = ["controlplane", "etcd"]
-      ssh_key           = file(var.ssh_private_key)
-    }
-  }
-
-  dynamic "nodes" {
-    for_each = [for node in var.worker_nodes : {
-      name = node["name"]
-      ip   = node["ip"]
-    }]
-    content {
-      address           = nodes.value.ip
-      hostname_override = nodes.value.name
-      user              = "ubuntu"
-      role              = ["worker"]
+      role              = ["controlplane", "etcd", "worker"]
       ssh_key           = file(var.ssh_private_key)
     }
   }

--- a/terraform/modules/kubernetes/rancher/main.tf
+++ b/terraform/modules/kubernetes/rancher/main.tf
@@ -94,7 +94,7 @@ resource "helm_release" "rancher" {
 
   set {
     name  = "ingress.extraAnnotations.nginx\\.ingress\\.kubernetes\\.io/server-alias"
-    value = join(",", formatlist("%s.nip.io", [for node in slice(var.cluster_nodes, 1, length(var.cluster_nodes)-1): node["ip"]]))
+    value = join(",", formatlist("%s.nip.io", [for node in slice(var.cluster_nodes, 1, length(var.cluster_nodes) - 1) : node["ip"]]))
   }
 
 }

--- a/terraform/modules/kubernetes/rancher/main.tf
+++ b/terraform/modules/kubernetes/rancher/main.tf
@@ -57,6 +57,7 @@ resource "helm_release" "cert-manager" {
   repository       = "https://charts.jetstack.io"
   namespace        = "cert-manager"
   create_namespace = "true"
+  wait             = "true"
 
   set {
     name  = "namespace"

--- a/terraform/modules/kubernetes/rancher/vars.tf
+++ b/terraform/modules/kubernetes/rancher/vars.tf
@@ -106,3 +106,8 @@ variable "rancher_vsphere_pool" {
   type    = string
   default = ""
 }
+
+variable "rancher_node_template_disk_size" {
+  type = number
+  default = 51200
+}

--- a/terraform/modules/kubernetes/rancher/vars.tf
+++ b/terraform/modules/kubernetes/rancher/vars.tf
@@ -32,12 +32,7 @@ variable "deliverables_path" {
   default     = "./deliverables"
 }
 
-variable "control_plane_nodes" {
-  type    = list
-  default = []
-}
-
-variable "worker_nodes" {
+variable "cluster_nodes" {
   type    = list
   default = []
 }

--- a/terraform/modules/kubernetes/rancher/vars.tf
+++ b/terraform/modules/kubernetes/rancher/vars.tf
@@ -108,6 +108,6 @@ variable "rancher_vsphere_pool" {
 }
 
 variable "rancher_node_template_disk_size" {
-  type = number
+  type    = number
   default = 51200
 }

--- a/terraform/vsphere-rancher/main.tf
+++ b/terraform/vsphere-rancher/main.tf
@@ -6,15 +6,14 @@ terraform {
 }
 
 locals {
-  control_plane_ips = length(var.static_ip_addresses) == 0 ? [] : slice(var.static_ip_addresses, 0, var.control_plane_count)
-  worker_ips        = length(var.static_ip_addresses) == 0 ? [] : slice(var.static_ip_addresses, var.control_plane_count, var.worker_count + var.control_plane_count)
+  cluster_node_ips = length(var.static_ip_addresses) == 0 ? [] : slice(var.static_ip_addresses, 0, var.cluster_node_count)
 }
 
 
-module "control_plane" {
+module "cluster_nodes" {
   source = "../modules/infrastructure/vsphere"
 
-  node_count             = var.control_plane_count
+  node_count             = var.cluster_node_count
   type                   = "control-plane"
   vm_datastore           = var.vm_datastore
   vm_name                = var.vm_name
@@ -30,31 +29,7 @@ module "control_plane" {
   vsphere_vm_folder      = var.vsphere_vm_folder
   vsphere_resource_pool  = var.vsphere_resource_pool
   ssh_public_key         = var.ssh_public_key
-  static_ip_addresses    = local.control_plane_ips
-  default_gateway        = var.default_gateway
-  dns_servers            = var.dns_servers
-}
-
-module "worker" {
-  source = "../modules/infrastructure/vsphere"
-
-  node_count             = var.worker_count
-  type                   = "worker"
-  vm_datastore           = var.vm_datastore
-  vm_name                = var.vm_name
-  vm_network             = var.vm_network
-  vm_cpu                 = var.vm_cpu
-  vm_ram                 = var.vm_ram
-  vm_template_name       = var.vm_template_name
-  vsphere_datacenter     = var.vsphere_datacenter
-  vsphere_password       = var.vsphere_password
-  vsphere_unverified_ssl = var.vsphere_unverified_ssl
-  vsphere_user           = var.vsphere_user
-  vsphere_vcenter        = var.vsphere_vcenter
-  vsphere_vm_folder      = var.vsphere_vm_folder
-  vsphere_resource_pool  = var.vsphere_resource_pool
-  ssh_public_key         = var.ssh_public_key
-  static_ip_addresses    = local.worker_ips
+  static_ip_addresses    = local.cluster_node_ips
   default_gateway        = var.default_gateway
   dns_servers            = var.dns_servers
 }
@@ -62,12 +37,11 @@ module "worker" {
 module "rancher" {
   source = "../modules/kubernetes/rancher"
 
-  vm_depends_on       = [module.worker.nodes, module.control_plane.nodes]
-  control_plane_nodes = module.control_plane.nodes
-  worker_nodes        = module.worker.nodes
-  rancher_server_url  = var.bootstrap_rancher ? length(local.control_plane_ips) == 0 ? join("", [module.worker.nodes[0].ip, ".nip.io"]) : var.rancher_server_url : var.rancher_server_url
-  ssh_private_key     = var.ssh_private_key
-  ssh_public_key      = var.ssh_public_key
+  vm_depends_on      = [module.cluster_nodes.nodes]
+  cluster_nodes      = module.cluster_nodes.nodes
+  rancher_server_url = var.bootstrap_rancher ? length(local.cluster_node_ips) == 0 ? join("", [module.cluster_nodes.nodes[0].ip, ".nip.io"]) : var.rancher_server_url : var.rancher_server_url
+  ssh_private_key    = var.ssh_private_key
+  ssh_public_key     = var.ssh_public_key
 
   rancher_password    = var.rancher_password
   create_user_cluster = var.rancher_create_user_cluster

--- a/terraform/vsphere-rancher/main.tf
+++ b/terraform/vsphere-rancher/main.tf
@@ -5,11 +5,6 @@ terraform {
   }
 }
 
-locals {
-  cluster_node_ips = length(var.static_ip_addresses) == 0 ? [] : slice(var.static_ip_addresses, 0, var.cluster_node_count)
-}
-
-
 module "cluster_nodes" {
   source = "../modules/infrastructure/vsphere"
 
@@ -29,7 +24,7 @@ module "cluster_nodes" {
   vsphere_vm_folder      = var.vsphere_vm_folder
   vsphere_resource_pool  = var.vsphere_resource_pool
   ssh_public_key         = var.ssh_public_key
-  static_ip_addresses    = local.cluster_node_ips
+  static_ip_addresses    = var.static_ip_addresses
   default_gateway        = var.default_gateway
   dns_servers            = var.dns_servers
 }
@@ -39,7 +34,7 @@ module "rancher" {
 
   vm_depends_on      = [module.cluster_nodes.nodes]
   cluster_nodes      = module.cluster_nodes.nodes
-  rancher_server_url = var.bootstrap_rancher ? length(local.cluster_node_ips) == 0 ? join("", [module.cluster_nodes.nodes[0].ip, ".nip.io"]) : var.rancher_server_url : var.rancher_server_url
+  rancher_server_url = var.bootstrap_rancher ? length(var.static_ip_addresses) == 0 ? join("", [module.cluster_nodes.nodes[0].ip, ".nip.io"]) : var.rancher_server_url : var.rancher_server_url
   ssh_private_key    = var.ssh_private_key
   ssh_public_key     = var.ssh_public_key
 

--- a/terraform/vsphere-rancher/main.tf
+++ b/terraform/vsphere-rancher/main.tf
@@ -14,7 +14,7 @@ module "cluster_nodes" {
   source = "../modules/infrastructure/vsphere"
 
   node_count             = var.cluster_node_count
-  type                   = "control-plane"
+  type                   = "node"
   vm_datastore           = var.vm_datastore
   vm_name                = var.vm_name
   vm_network             = var.vm_network

--- a/terraform/vsphere-rancher/outputs.tf
+++ b/terraform/vsphere-rancher/outputs.tf
@@ -1,9 +1,5 @@
-output "control_plane_nodes" {
-  value = module.control_plane.nodes
-}
-
-output "worker_nodes" {
-  value = module.worker.nodes
+output "cluster_nodes" {
+  value = module.cluster_nodes.nodes
 }
 
 output "rancher_server_url" {

--- a/terraform/vsphere-rancher/variables.tf
+++ b/terraform/vsphere-rancher/variables.tf
@@ -1,11 +1,7 @@
-variable "worker_count" {
-  type        = number
-  description = "Number of worker nodes"
-}
-
-variable "control_plane_count" {
+variable "cluster_node_count" {
   type        = number
   description = "Number of control plane nodes"
+  default     = 3
 }
 
 variable "vsphere_user" {

--- a/terraform/vsphere-rancher/variables.tf
+++ b/terraform/vsphere-rancher/variables.tf
@@ -1,6 +1,6 @@
 variable "cluster_node_count" {
   type        = number
-  description = "Number of control plane nodes"
+  description = "Number of cluster nodes"
   default     = 3
 }
 


### PR DESCRIPTION
* Deploy 3 all-in-one nodes by default
  * Removed the parameters for `control_plane` and `worker` node counts. Deployment will now default to 3 all-in-one nodes for the Rancher cluster. This is the recommended configuration, and will make the rancher service resilient to node failures.
  * These have been condensed into a single resource, `cluster_node`, which will be deployed with all 3 roles (`controlplane`, `etcd`, `worker`)
* Add additional server aliases to ingress
  * Automatically create **\<ip>.nip.io** [server aliases](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-alias) for the secondary and tertiary cluster nodes on the rancher service ingress resource. This will provide additional routes to access the rancher service, in the event the primary node fails, as users are likely to have DNS configured only for the first node in the rancher cluster.
* Update GitHub workflow to execute tests via docker

