### PR TITLE
add make image/push allowing registry and tag as env variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ push: ## Push a Container image (terraform-rancher:$IMAGE_TAG) to the specified 
 
 .PHONY: shell
 shell:  ## Drop into a docker shell with terraform
-	docker run -it --rm -v ${PWD}/rancher.tfvars:/terraform/vsphere-rancher/terraform.tfvars -v ${PWD}/deliverables:/terraform/vsphere-rancher/deliverables --entrypoint /bin/sh terraform-rancher:latest
+	docker run -it --rm -v ${PWD}/rancher.tfvars:/terraform/vsphere-rancher/terraform.tfvars -v ${PWD}/deliverables:/terraform/vsphere-rancher/deliverables --entrypoint /bin/sh terraform-rancher:${IMAGE_TAG}
 	true
 
 .PHONY: validate

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
+IMAGE_TAG ?= dev
+REGISTRY ?= index.docker.io/netapp # Can substitute gcr, quay or registry:5000
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: image
-image:  ## Build container image
-	docker build -t terraform-rancher:latest .
+image:  ## Build container image (set $IMAGE_TAG or use default of `dev`)
+	docker build -t terraform-rancher:${IMAGE_TAG} .
+
+.PHONY: push
+push: ## Push a Container image (terraform-rancher:$IMAGE_TAG) to the specified registry ($REGISTRY, defaults to `index.docker.io` )
+	docker tag terraform-rancher:${IMAGE_TAG} ${REGISTRY}/terraform-rancher:${IMAGE_TAG}
+	docker push ${REGISTRY}/terraform-rancher:${IMAGE_TAG}
 
 .PHONY: shell
 shell:  ## Drop into a docker shell with terraform

--- a/README.md
+++ b/README.md
@@ -92,3 +92,23 @@ terraform destroy -var-file=terraform.tfvars -state=deliverables/terraform.tfsta
 docker login docker.pkg.github.com -u <GITHUB_USER> -p <GITHUB_ACCESS_TOKEN> 
 docker pull docker.pkg.github.com/netapp/ez-rancher/terraform-rancher:latest
 ```
+
+## Creating container images
+You can use the `make image` command to easily build a terraform-rancher
+container image with all the necessary dependencies.  This will be built
+based on the current status of your src directory.
+
+By default we set an Image Tag of "dev" eg terraform-rancher:dev.  You can
+change this tag by setting the `IMAGE_TAG` environment variable to your
+desired tag (eg `latest` which we build and publish for each commit).
+
+## Pushing images to a container registry
+After building your image, you can also easily push it to your container
+registry using the Makefile.  By default, we set a container registry
+environment variable ($REGISTRY) to `index.docker.io/netapp`.  You can
+set this environment varialbe to your own dockerhub account as well as
+quay, or gcr and push dev builds to your own registry if you like by running
+`make push`.
+
+The `push` directive honors both the `IMAGE_TAG` env variable and the `REGISTRY`
+env variable.

--- a/hack/runner.sh
+++ b/hack/runner.sh
@@ -23,4 +23,5 @@ if [ ! -d "$deliverables" ]; then
   mkdir -p "$deliverables"
 fi
 
+make image
 docker run -it --rm -v "$tfvars":/terraform/vsphere-rancher/rancher.tfvars -v "$deliverables":/terraform/vsphere-rancher/deliverables terraform-rancher:"$IMAGE_TAG" "$operation" -auto-approve -var-file=/terraform/vsphere-rancher/rancher.tfvars -state=deliverables/terraform.tfstate

--- a/hack/runner.sh
+++ b/hack/runner.sh
@@ -19,9 +19,8 @@ fi
 if [ ! -d "$deliverables" ]; then
   echo 'Local deliverables file not found at:'
   echo "$deliverables"
-  echo 'Exiting'
-  exit 1;
+  echo 'Attempting to create it for you...'
+  mkdir -p "$deliverables"
 fi
 
-make image
 docker run -it --rm -v "$tfvars":/terraform/vsphere-rancher/rancher.tfvars -v "$deliverables":/terraform/vsphere-rancher/deliverables terraform-rancher "$operation" -state=deliverables/terraform.tfstate

--- a/hack/runner.sh
+++ b/hack/runner.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+IMAGE_TAG=${IMAGE_TAG:-dev}
 if ( ! docker stats --no-stream > /dev/null ); then
   echo 'Docker daemon is not running. Exiting'
   exit 1;
@@ -8,7 +9,6 @@ fi
 operation=$1
 tfvars=${2:-"${PWD}/rancher.tfvars"}
 deliverables=${3:-"${PWD}/deliverables"}
-
 if [ ! -f "$tfvars" ]; then
   echo 'Local tfvars file not found at:'
   echo "$tfvars"
@@ -23,4 +23,4 @@ if [ ! -d "$deliverables" ]; then
   mkdir -p "$deliverables"
 fi
 
-docker run -it --rm -v "$tfvars":/terraform/vsphere-rancher/rancher.tfvars -v "$deliverables":/terraform/vsphere-rancher/deliverables terraform-rancher "$operation" -state=deliverables/terraform.tfstate
+docker run -it --rm -v "$tfvars":/terraform/vsphere-rancher/rancher.tfvars -v "$deliverables":/terraform/vsphere-rancher/deliverables terraform-rancher:"$IMAGE_TAG" "$operation" -auto-approve -var-file=/terraform/vsphere-rancher/rancher.tfvars -state=deliverables/terraform.tfstate


### PR DESCRIPTION
Add some basic container image management options to Makefile

Add ability to evaluate `IMAGE_TAG` and `REGISTRY` environment variables in order to build and push images using the Makefile.

This change adds a default tag of `dev` to the `make image` directive, and also introduces an environment variable check ($IMAGE_TAG) to easily set the tag to whatever you might want.

In addition, this change also adds a `push` directive to the Makefile to use to push an image you might build to a container registry.  This also uses a new environment variable check ($REGISTRY) to allow you to specify your own container registry to push an image to.  By default we set this to the dockerhub netapp account, but you can override this by setting the variable to your dockerhub registry as well as quay.io or gcr.  NOTE we don't do anything fancy with tokens or auth, that's up to you to set up beforehand.
