### PR TITLE
Generate SSH keys within module

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -11,7 +11,7 @@ on:
         description: Git Ref (Optional)    
         required: false
   schedule:
-    - cron: '45 * * * *'
+    - cron: '0 */4 * * *'
 
 jobs:
   validate:
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v2
       
       - name: Build image
-        run: sudo docker build -t terraform-rancher:latest .
+        run: sudo docker build --no-cache -t terraform-rancher:latest .
 
       - name: Create vars file
         env:
@@ -109,5 +109,8 @@ jobs:
           sudo docker run --rm -v `pwd`/deliverables-$COMMIT_ID:/terraform/vsphere-rancher/deliverables \
             --env-file env.list \
             terraform-rancher:latest destroy -input="false" -auto-approve
+      
+      - name: Remove image
+        run: sudo docker rmi terraform-rancher:latest
 
           

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -11,6 +11,7 @@ on:
         description: Git Ref (Optional)    
         required: false
   schedule:
+    # Run every 4 hours
     - cron: '0 */4 * * *'
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apk add --no-cache curl \
   && mv terraform-provider-rke-*/terraform-provider-rke /root/.terraform.d/plugins/linux_amd64/terraform-provider-rke \
   && rm -rf terraform-provider-rke-linux-amd64.tar.gz \
   && rm -rf terraform-provider-rke-* \
-  && ssh-keygen -q -t rsa -N '' -f ~/.ssh/id_rsa \
   && apk del --no-cache .build-deps \
   && curl -LO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
   && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip \

--- a/terraform/modules/infrastructure/vsphere/05-vars.tf
+++ b/terraform/modules/infrastructure/vsphere/05-vars.tf
@@ -89,18 +89,6 @@ variable "vm_domain" {
   default     = ""
 }
 
-variable "ssh_private_key" {
-  type        = string
-  description = "SSH private key"
-  default     = "~/.ssh/id_rsa"
-}
-
-variable "ssh_public_key" {
-  type        = string
-  description = "SSH public key"
-  default     = "~/.ssh/id_rsa.pub"
-}
-
 variable "static_ip_addresses" {
   type        = list
   description = "List of IP addresses"

--- a/terraform/modules/infrastructure/vsphere/10-data.tf
+++ b/terraform/modules/infrastructure/vsphere/10-data.tf
@@ -39,7 +39,7 @@ data "template_file" "userdata" {
   count    = var.node_count
   template = file("${path.module}/cloudinit/kickstart-userdata.yaml")
   vars = {
-    ssh_public_key = file(var.ssh_public_key)
+    ssh_public_key = tls_private_key.key.public_key_openssh
     netplan        = base64encode(data.template_file.netplan[count.index].rendered)
   }
 }

--- a/terraform/modules/infrastructure/vsphere/11-inf.tf
+++ b/terraform/modules/infrastructure/vsphere/11-inf.tf
@@ -1,4 +1,9 @@
 
+resource "tls_private_key" "key" {
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P384"
+}
+
 resource "vsphere_virtual_machine" "node" {
   count            = var.node_count
   name             = format("${var.vm_name}-${var.type}%02d", count.index + 1)

--- a/terraform/modules/infrastructure/vsphere/outputs.tf
+++ b/terraform/modules/infrastructure/vsphere/outputs.tf
@@ -11,3 +11,12 @@ output "nodes" {
     }
   ]
 }
+
+output "ssh_public_key" {
+  value = tls_private_key.key.public_key_openssh
+}
+
+output "ssh_private_key" {
+  value     = tls_private_key.key.private_key_pem
+  sensitive = true
+}

--- a/terraform/modules/kubernetes/rancher/main.tf
+++ b/terraform/modules/kubernetes/rancher/main.tf
@@ -17,7 +17,7 @@ resource "rke_cluster" "cluster" {
       hostname_override = nodes.value.name
       user              = "ubuntu"
       role              = ["controlplane", "etcd", "worker"]
-      ssh_key           = file(var.ssh_private_key)
+      ssh_key           = var.ssh_private_key
     }
   }
 }
@@ -34,13 +34,13 @@ resource "local_file" "rkeconfig" {
 
 resource "local_file" "ssh_private_key" {
   filename        = format("${local.deliverables_path}/id_rsa")
-  content         = file(var.ssh_private_key)
+  content         = var.ssh_private_key
   file_permission = "600"
 }
 
 resource "local_file" "ssh_public_key" {
   filename        = format("${local.deliverables_path}/id_rsa.pub")
-  content         = file(var.ssh_public_key)
+  content         = var.ssh_public_key
   file_permission = "644"
 }
 

--- a/terraform/vsphere-rancher/main.tf
+++ b/terraform/vsphere-rancher/main.tf
@@ -23,7 +23,7 @@ module "cluster_nodes" {
   vsphere_vcenter        = var.vsphere_vcenter
   vsphere_vm_folder      = var.vsphere_vm_folder
   vsphere_resource_pool  = var.vsphere_resource_pool
-  ssh_public_key         = var.ssh_public_key
+  ssh_public_key         = join("", [var.deliverables_path, "/id_rsa.pub"])
   static_ip_addresses    = var.static_ip_addresses
   default_gateway        = var.default_gateway
   dns_servers            = var.dns_servers
@@ -35,8 +35,8 @@ module "rancher" {
   vm_depends_on      = [module.cluster_nodes.nodes]
   cluster_nodes      = module.cluster_nodes.nodes
   rancher_server_url = var.bootstrap_rancher ? length(var.static_ip_addresses) == 0 ? join("", [module.cluster_nodes.nodes[0].ip, ".nip.io"]) : var.rancher_server_url : var.rancher_server_url
-  ssh_private_key    = var.ssh_private_key
-  ssh_public_key     = var.ssh_public_key
+  ssh_private_key    = module.cluster_nodes.ssh_private_key
+  ssh_public_key     = module.cluster_nodes.ssh_public_key
 
   rancher_password    = var.rancher_password
   create_user_cluster = var.rancher_create_user_cluster

--- a/terraform/vsphere-rancher/main.tf
+++ b/terraform/vsphere-rancher/main.tf
@@ -23,7 +23,6 @@ module "cluster_nodes" {
   vsphere_vcenter        = var.vsphere_vcenter
   vsphere_vm_folder      = var.vsphere_vm_folder
   vsphere_resource_pool  = var.vsphere_resource_pool
-  ssh_public_key         = join("", [var.deliverables_path, "/id_rsa.pub"])
   static_ip_addresses    = var.static_ip_addresses
   default_gateway        = var.default_gateway
   dns_servers            = var.dns_servers


### PR DESCRIPTION
Addresses https://github.com/NetApp/ez-rancher/issues/36.

No longer generating SSH key pair while building the deployment container. 

This PR moves `ssh-keygen` functionality into the infrastructure module, so that a new random key pair will be generated prior to creating the cluster nodes. Keys will continue to be exported to the deliverables directory, and their lifecycle will be tied to that of the TF project.