### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,20 +1,17 @@
 name: Publish to Registry
 on:
-  release:
-    types: [published]
   push:
     branches:
       - main
-  schedule:
-    - cron: '*/15 * * * *' # Every 15 minutes
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - run: git fetch --prune --unshallow
       - name: Get release version
         id: get_version
-        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+        run: echo ::set-env name=RELEASE_VERSION::$(git describe --tags --abbrev=0)
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@master
         with:


### PR DESCRIPTION
Update publish workflow to tag image with the latest available tag, e.g:

```
$ git describe --tags --abbrev=0
v0.1.0-alpha
```

This should reduce the overall number of Released images we push to the repo.
