### PR TITLE
Target node resources during destroy

### DIFF
--- a/hack/runner.sh
+++ b/hack/runner.sh
@@ -38,9 +38,11 @@ if [ ! -d "$DELIVERABLES" ]; then
   mkdir -p "$DELIVERABLES"
 fi
 
-docker run -it --rm -v "$TFVARS":/terraform/vsphere-rancher/rancher.tfvars -v "$DELIVERABLES":/terraform/vsphere-rancher/deliverables terraform-rancher:"$IMAGE_TAG" "$OPERATION" -auto-approve -var-file=/terraform/vsphere-rancher/rancher.tfvars -state=deliverables/terraform.tfstate
-
 if [ "$OPERATION" == "destroy" ]; then
+  docker run -it --rm -v "$TFVARS":/terraform/vsphere-rancher/rancher.tfvars -v "$DELIVERABLES":/terraform/vsphere-rancher/deliverables terraform-rancher:"$IMAGE_TAG" state rm module.rancher
+  docker run -it --rm -v "$TFVARS":/terraform/vsphere-rancher/rancher.tfvars -v "$DELIVERABLES":/terraform/vsphere-rancher/deliverables terraform-rancher:"$IMAGE_TAG" "$OPERATION" -auto-approve -var-file=/terraform/vsphere-rancher/rancher.tfvars -target=module.cluster_nodes.vsphere_virtual_machine.node
   echo "removing contents of deliverables directory..."
   rm -rf "$DELIVERABLES"
+else
+  docker run -it --rm -v "$TFVARS":/terraform/vsphere-rancher/rancher.tfvars -v "$DELIVERABLES":/terraform/vsphere-rancher/deliverables terraform-rancher:"$IMAGE_TAG" "$OPERATION" -auto-approve -var-file=/terraform/vsphere-rancher/rancher.tfvars
 fi

--- a/hack/runner.sh
+++ b/hack/runner.sh
@@ -39,6 +39,8 @@ if [ ! -d "$DELIVERABLES" ]; then
 fi
 
 if [ "$OPERATION" == "destroy" ]; then
+  # Remove Rancher resources from project state prior to running destroy. 
+  # This will allow any additional clusters that the user has created to be retained.
   docker run -it --rm -v "$TFVARS":/terraform/vsphere-rancher/rancher.tfvars -v "$DELIVERABLES":/terraform/vsphere-rancher/deliverables terraform-rancher:"$IMAGE_TAG" state rm module.rancher
   docker run -it --rm -v "$TFVARS":/terraform/vsphere-rancher/rancher.tfvars -v "$DELIVERABLES":/terraform/vsphere-rancher/deliverables terraform-rancher:"$IMAGE_TAG" "$OPERATION" -auto-approve -var-file=/terraform/vsphere-rancher/rancher.tfvars -target=module.cluster_nodes.vsphere_virtual_machine.node
   echo "removing contents of deliverables directory..."


### PR DESCRIPTION
Update `destroy` command in runner script to remove all rancher resources from the project state, and run the destroy command against the node resources directly. This works around the behavior described in https://github.com/NetApp/ez-rancher/issues/48. 

Since the contents of the deliverables directory will also be removed by the script, this change should not result in any dangling artifacts.