### PR TITLE
run etcd on single node

### DIFF
--- a/terraform/modules/kubernetes/rancher/main.tf
+++ b/terraform/modules/kubernetes/rancher/main.tf
@@ -8,7 +8,7 @@ resource "rke_cluster" "cluster" {
   # 2 minute timeout specifically for rke-network-plugin-deploy-job but will apply to any addons
   addon_job_timeout = 120
   dynamic "nodes" {
-    for_each = [for node in var.cluster_nodes : {
+    for_each = [for node in [var.cluster_nodes[0]] : {
       name = node["name"]
       ip   = node["ip"]
     }]
@@ -17,6 +17,20 @@ resource "rke_cluster" "cluster" {
       hostname_override = nodes.value.name
       user              = "ubuntu"
       role              = ["controlplane", "etcd", "worker"]
+      ssh_key           = var.ssh_private_key
+    }
+  }
+
+  dynamic "nodes" {
+    for_each = [for node in slice(var.cluster_nodes, 1, length(var.cluster_nodes)) : {
+      name = node["name"]
+      ip   = node["ip"]
+    }]
+    content {
+      address           = nodes.value.ip
+      hostname_override = nodes.value.name
+      user              = "ubuntu"
+      role              = ["controlplane", "worker"]
       ssh_key           = var.ssh_private_key
     }
   }


### PR DESCRIPTION
This is a proposed short-term workaround for the `etcdserver` errors described here: https://github.com/NetApp/ez-rancher/issues/51

This seems to be an issue that may have been introduced by merging https://github.com/NetApp/ez-rancher/pull/31, wherein `etcd` now runs on all nodes in the cluster. 

These errors seem to occur when the state of the etcd cluster changes, in such a way that causes the helm deployments to fail partway through. The etcdserver appears to recover shortly after this error occurs, and re-running  `terraform apply` against the project results in success - still, this error seems to be popping up during 10-15% of deployments.

While this reduces the overall availability of the management cluster, it will give us improved stability for early releases, which I think will result in a better user experience overall.