### PR TITLE
add use_auto_dns_url flag

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -81,6 +81,7 @@ jobs:
           TF_VAR_rancher_password: ${{ secrets.TF_RANCHER_PASSWORD }}
           TF_VAR_bootstrap_rancher: true
           TF_VAR_vsphere_resource_pool: ${{ secrets.TF_VSPHERE_RESOURCE_POOL }}
+          TF_VAR_use_auto_dns_url: true
         run: |
           export COMMIT_ID=$(echo $GITHUB_CONTEXT | jq -r '.sha' | cut -c1-7)
           mkdir deliverables-$COMMIT_ID

--- a/README.md
+++ b/README.md
@@ -39,13 +39,19 @@ Network connectivity from where terraform is executed to the `vm_network`. The `
 
 #### DNS
 
-The `rancher_server_url` input must resolve to one of the worker node IPs.
+The `rancher_server_url` input must resolve to one or more of the worker node IPs.
 
 If DHCP is used (default), this can be done after the deployment completes and the worker nodes receive an IP from the `vm_network`.
 
-**Supplemental DNS names**
+#### Auto DNS URL
 
-See [Automatic DNS names](#automatic-dns-names)
+If the `use_auto_dns_url` parameter is set to `true`, then the `rancher_server_url` will be automatically set to the following URL:
+```bash
+https://<IP of primary node>.nip.io
+```
+
+This URL allow you to start using the Rancher UI right away, eliminating the need to configure DNS manually.
+
 
 ## Getting Started
 
@@ -179,10 +185,7 @@ Once the DNS record is in place, the Rancher UI will become accessible at the lo
 
 #### Automatic DNS Names
 
-If you have not yet configured DNS (or prefer not to), the Rancher UI can also be accessed via the following URL syntax, using the IP address of any node in the cluster:
-```bash
-https://<IP of node>.nip.io
-```
+* See [Auto DNS URL](#auto-dns-url)
 
 ## Admin Access to Cluster Nodes
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,14 @@ Once the DNS record is in place, the Rancher UI will become accessible at the lo
 
 #### Automatic DNS Names
 
-* See [Auto DNS URL](#auto-dns-url)
+If you have not yet configured DNS, the Rancher UI can also be accessed via the following URL syntax, using the IP address of any node in the cluster:
+
+```bash
+https://<IP of node>.nip.io
+```
+
+*note: A valid DNS record must be in place for `rancher_server_url` before Rancher will become fully functional. To eliminate this DNS requirement, see [Auto DNS URL](#auto-dns-url)*
+
 
 ## Admin Access to Cluster Nodes
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If the `use_auto_dns_url` parameter is set to `true`, then the `rancher_server_u
 https://<IP of primary node>.nip.io
 ```
 
-This URL allow you to start using the Rancher UI right away, eliminating the need to configure DNS manually.
+This URL allow you to start using Rancher right away, eliminating the need to configure DNS manually.
 
 
 ## Getting Started
@@ -191,7 +191,7 @@ If you have not yet configured DNS, the Rancher UI can also be accessed via the 
 https://<IP of node>.nip.io
 ```
 
-*note: A valid DNS record must be in place for `rancher_server_url` before Rancher will become fully functional. To eliminate this DNS requirement, see [Auto DNS URL](#auto-dns-url)*
+*note: A valid DNS record must be in place for the `rancher_server_url` before Rancher will become fully functional. To eliminate this DNS requirement, see [Auto DNS URL](#auto-dns-url)*
 
 
 ## Admin Access to Cluster Nodes

--- a/rancher.tfvars.example
+++ b/rancher.tfvars.example
@@ -64,15 +64,15 @@ vsphere_resource_pool = "mypool"
 # Rancher server URL
 rancher_server_url = "my.rancher.org"
 
+# Automatically set rancher_server_url URL to <node ip>.nip.io
+use_auto_dns_url = false
+
 # Automatically configure rancher:
 # - Updates the default admin password, provided by the rancher_password variable.
 # - Enables telemetry 
 # - Creates cloud credentials for vCenter
 # - Creates node template for vCenter
 bootstrap_rancher = true
-
-# Automatically set rancher_server_url URL to <node ip>.nip.io
-use_auto_dns_url = true
 
 # rancher default admin password
 rancher_password  = "solidfire"

--- a/rancher.tfvars.example
+++ b/rancher.tfvars.example
@@ -71,6 +71,9 @@ rancher_server_url = "my.rancher.org"
 # - Creates node template for vCenter
 bootstrap_rancher = true
 
+# Automatically set rancher_server_url URL to <node ip>.nip.io
+use_auto_dns_url = true
+
 # rancher default admin password
 rancher_password  = "solidfire"
 

--- a/terraform/modules/kubernetes/rancher/bootstrap.tf
+++ b/terraform/modules/kubernetes/rancher/bootstrap.tf
@@ -51,6 +51,15 @@ resource "rancher2_cloud_credential" "vsphere" {
   }
 }
 
+resource "rancher2_setting" "server_url" {
+  count      = var.bootstrap_rancher ? 1 : 0
+  provider   = rancher2.admin
+  depends_on = [rancher2_node_template.vsphere]
+
+  name  = "server-url"
+  value = join("", ["https://", var.rancher_server_url])
+}
+
 resource "rancher2_node_template" "vsphere" {
   count = var.bootstrap_rancher ? 1 : 0
 

--- a/terraform/vsphere-rancher/main.tf
+++ b/terraform/vsphere-rancher/main.tf
@@ -34,7 +34,7 @@ module "rancher" {
 
   vm_depends_on      = [module.cluster_nodes.nodes]
   cluster_nodes      = module.cluster_nodes.nodes
-  rancher_server_url = var.rancher_server_url
+  rancher_server_url = var.use_auto_dns_url ? join("", [module.cluster_nodes.nodes[0].ip, ".nip.io"]) : var.rancher_server_url
   ssh_private_key    = module.cluster_nodes.ssh_private_key
   ssh_public_key     = module.cluster_nodes.ssh_public_key
 

--- a/terraform/vsphere-rancher/variables.tf
+++ b/terraform/vsphere-rancher/variables.tf
@@ -147,5 +147,5 @@ variable "bootstrap_rancher" {
 
 variable "use_auto_dns_url" {
   type    = bool
-  default = true
+  default = false
 }

--- a/terraform/vsphere-rancher/variables.tf
+++ b/terraform/vsphere-rancher/variables.tf
@@ -144,3 +144,8 @@ variable "bootstrap_rancher" {
   type    = string
   default = true
 }
+
+variable "use_auto_dns_url" {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION
* Always configure Rancher's `server-url` setting to match `rancher_server_url` parameter
  * Fixes https://github.com/NetApp/ez-rancher/issues/58
* Add `use_auto_dns_url` parameter
  * Defaults to `false`
  * This will influence whether or not the `rancher_server_url` will be modified. If `true`, `rancher_server_url` will be overridden to `<node IP>.nip.io`.
  * If `use_auto_dns` is set to `false`, then the user will need to ensure that a DNS record is in place so `rancher_server_url` resolves to one or more of their nodes. **Attempts to create user clusters will fail until this is configured**.
