### PR TITLE
pull terragrunt release on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,4 @@
-# docker build -t ez-rancher:latest .
-# docker run -it --rm -v ${PWD}/rancher.tfvars:/terraform/vsphere-rancher/rancher.tfvars -v ${PWD}/deliverables:/terraform/vsphere-rancher/deliverables ez-rancher:latest apply -state=deliverables/terraform.tfstate
-FROM golang:alpine3.12 as builder
-
-RUN apk add --no-cache git && \
-  git clone https://github.com/sgryczan/terragrunt.git && \
-  cd terragrunt && \
-  go build -o terragrunt -v && \
-  chmod +x terragrunt && \
-  mv terragrunt /usr/local/bin && \
-  cd .. && rm -rf terragrunt/
-
 FROM alpine:3.12.0
-
-COPY --from=builder /usr/local/bin/terragrunt /bin/terragrunt
 
 ARG EZR_COMPRESS_BINARIES=false
 ARG GIT_COMMIT=unspecified
@@ -21,6 +7,7 @@ LABEL git_commit=$GIT_COMMIT
 ENV KUBECTL_VERSION=v1.18.3
 ENV RKE_PROVIDER_VERSION=1.0.1
 ENV TERRAFORM_VERSION=0.12.26
+ENV TERRAGRUNT_VERSION=v0.23.31-r.1
 
 COPY hack/compress_binaries.sh /compress_binaries.sh
 COPY hack/install_upx.sh /install_upx.sh
@@ -41,6 +28,10 @@ RUN apk add --no-cache --virtual .build-deps curl \
   && apk del --no-cache .build-deps \
   && rm -rf /tf-provider-rke.zip \
   && if ${EZR_COMPRESS_BINARIES}; then /install_upx.sh; /compress_binaries.sh; fi
+
+RUN apk add --no-cache --virtual .build-deps curl && \
+    curl -Lo /bin/terragrunt https://github.com/sgryczan/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 && \
+    chmod +x /bin/terragrunt
 
 COPY terraform/ /terraform/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# docker build -t ez-rancher:latest .
+# docker run -it --rm -v ${PWD}/rancher.tfvars:/terraform/vsphere-rancher/rancher.tfvars -v ${PWD}/deliverables:/terraform/vsphere-rancher/deliverables ez-rancher:latest apply -state=deliverables/terraform.tfstate
 FROM alpine:3.12.0
 
 ARG EZR_COMPRESS_BINARIES=false


### PR DESCRIPTION
* Pull a [release package](https://github.com/sgryczan/terragrunt/releases/) for Terragrunt instead of building from source. This reduces image build time significantly, from > 2 minutes to ~40 seconds.