### PR TITLE
Pin RKE version to 1.18.10 to support Trident

### DIFF
--- a/rancher.tfvars.example
+++ b/rancher.tfvars.example
@@ -125,4 +125,4 @@ rancher_password = "rancher"
 # kubernetes_version = "v1.18.10-rancher1-2"
 
 # (Optional) The Rancher version to install
-# rancher_version = "2.5.0"
+# rancher_version = "2.4.8"

--- a/rancher.tfvars.example
+++ b/rancher.tfvars.example
@@ -120,3 +120,9 @@ rancher_password = "rancher"
 
 # (Optional) The CIDR pool used to assign IP addresses to services in the cluster
 # rancher_service_cidr = "10.43.0.0/16"
+
+# (Optional) The RKE version to install
+# kubernetes_version = "v1.18.10-rancher1-2"
+
+# (Optional) The Rancher version to install
+# rancher_version = "2.5.0"

--- a/terraform/modules/kubernetes/rancher/main.tf
+++ b/terraform/modules/kubernetes/rancher/main.tf
@@ -19,7 +19,8 @@ locals {
 resource "rke_cluster" "cluster" {
   depends_on = [var.vm_depends_on]
   # 2 minute timeout specifically for rke-network-plugin-deploy-job but will apply to any addons
-  addon_job_timeout = 120
+  addon_job_timeout  = 120
+  kubernetes_version = var.kubernetes_version
   services {
     kube_api {
       service_cluster_ip_range = var.rancher_service_cidr
@@ -118,6 +119,7 @@ resource "helm_release" "rancher" {
   create_namespace = "true"
   wait             = "true"
   replace          = true
+  version          = var.rancher_version
 
   set {
     name  = "namespace"

--- a/terraform/modules/kubernetes/rancher/vars.tf
+++ b/terraform/modules/kubernetes/rancher/vars.tf
@@ -139,3 +139,13 @@ variable "rancher_service_cidr" {
   type    = string
   default = "10.43.0.0/16"
 }
+
+variable "kubernetes_version" {
+  type    = string
+  default = "v1.18.10-rancher1-2"
+}
+
+variable "rancher_version" {
+  type    = string
+  default = ""
+}

--- a/terraform/vsphere-rancher/main.tf
+++ b/terraform/vsphere-rancher/main.tf
@@ -69,4 +69,6 @@ module "rancher" {
   no_proxy                     = var.no_proxy
   rancher_cluster_cidr         = var.rancher_cluster_cidr
   rancher_service_cidr         = var.rancher_service_cidr
+  kubernetes_version           = var.kubernetes_version
+  rancher_version              = var.rancher_version
 }

--- a/terraform/vsphere-rancher/variables.tf
+++ b/terraform/vsphere-rancher/variables.tf
@@ -184,3 +184,13 @@ variable "rancher_service_cidr" {
   type    = string
   default = "10.43.0.0/16"
 }
+
+variable "kubernetes_version" {
+  type    = string
+  default = "v1.18.10-rancher1-2"
+}
+
+variable "rancher_version" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
-Also added parameter for configuring rancher version but still using latest by default