### PR TITLE
Retry for generic error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache --virtual .build-deps curl \
   && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
   && rm -rf terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
   && mv terraform /bin/terraform \
-  && curl -Lo /bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 \
+  && curl -Lo /bin/terragrunt https://github.com/NetApp/terragrunt/releases/download/v0.26.7-netapp/terragrunt-linux-amd64 \
   && chmod +x /bin/terragrunt \
   && apk del --no-cache .build-deps
 

--- a/hack/runner.sh
+++ b/hack/runner.sh
@@ -14,7 +14,7 @@
 #
 # Copyright 2020 NetApp
 #
-OPERATION=$1
+OPERATION=${1:-apply}
 EZR_IMAGE_NAME=${EZR_IMAGE_NAME:-netapp/ez-rancher}
 EZR_IMAGE_TAG=${EZR_IMAGE_TAG:-latest}
 TFVARS=${EZR_VARS_FILE:-"${PWD}/rancher.tfvars"}

--- a/terraform/vsphere-rancher/terragrunt.hcl
+++ b/terraform/vsphere-rancher/terragrunt.hcl
@@ -1,4 +1,5 @@
 retryable_errors = [
   ".*etcdserver: leader changed.*",
   ".*etcdserver: request timed out.*",
+  ".*Cluster must have at least one etcd plane host.*",
 ]


### PR DESCRIPTION
Given 

> time="2020-12-02T15:26:11Z" level=info msg="time=\"2020-12-02T15:26:11Z\" level=info msg=\"Building Kubernetes cluster\""
> time="2020-12-02T15:26:11Z" level=info
> time="2020-12-02T15:26:11Z" level=info msg="Failed running cluster err:Cluster must have at least one etcd plane host: please specify one or more etcd in cluster config"
> time="2020-12-02T15:26:11Z" level=info msg="========================================"
> time="2020-12-02T15:26:11Z" level=info
> time="2020-12-02T15:26:11Z" level=info
> time="2020-12-02T15:26:11Z" level=info msg="  on ../modules/kubernetes/rancher/main.tf line 19, in resource \"rke_cluster\" \"cluster\":"
> time="2020-12-02T15:26:11Z" level=info msg="  19: resource \"rke_cluster\" \"cluster\" {"
> time="2020-12-02T15:26:11Z" level=info

 
Let terragrunt retry.