### PR TITLE
Support limit  the number of master nodes

### DIFF
--- a/terraform/modules/kubernetes/rancher/main.tf
+++ b/terraform/modules/kubernetes/rancher/main.tf
@@ -16,6 +16,11 @@ locals {
   alias_initial_node = var.rancher_server_url == join("", [var.cluster_nodes[0].ip, ".nip.io"]) ? 1 : 0
 }
 
+locals {
+  mgr_roles    = ["controlplane","etcd", "worker"]
+  worker_roles = ["worker"]
+}
+
 resource "rke_cluster" "cluster" {
   depends_on = [var.vm_depends_on]
   # 2 minute timeout specifically for rke-network-plugin-deploy-job but will apply to any addons
@@ -39,7 +44,7 @@ resource "rke_cluster" "cluster" {
       address           = nodes.value.ip
       hostname_override = nodes.value.name
       user              = "ubuntu"
-      role              = ["controlplane", "etcd", "worker"]
+      role = nodes.key  < var.cluster_master_node_count ? local.mgr_roles : local.worker_roles
       ssh_key           = var.ssh_private_key
     }
   }

--- a/terraform/modules/kubernetes/rancher/vars.tf
+++ b/terraform/modules/kubernetes/rancher/vars.tf
@@ -30,6 +30,11 @@ variable "deliverables_path" {
   default     = "./deliverables"
 }
 
+variable "cluster_master_node_count" {
+  type    = string
+  default = 3
+}
+
 variable "cluster_nodes" {
   type    = list(any)
   default = []

--- a/terraform/vsphere-rancher/main.tf
+++ b/terraform/vsphere-rancher/main.tf
@@ -43,12 +43,13 @@ module "cluster_nodes" {
 module "rancher" {
   source = "../modules/kubernetes/rancher"
 
-  vm_depends_on      = [module.cluster_nodes.nodes]
-  cluster_nodes      = module.cluster_nodes.nodes
-  rancher_server_url = var.use_auto_dns_url ? join("", [module.cluster_nodes.nodes[0].ip, ".nip.io"]) : var.rancher_server_url
-  ssh_private_key    = module.cluster_nodes.ssh_private_key
-  ssh_public_key     = module.cluster_nodes.ssh_public_key
-  deliverables_path  = var.deliverables_path
+  vm_depends_on             = [module.cluster_nodes.nodes]
+  cluster_nodes             = module.cluster_nodes.nodes
+  cluster_master_node_count = var.cluster_master_node_count
+  rancher_server_url        = var.use_auto_dns_url ? join("", [module.cluster_nodes.nodes[0].ip, ".nip.io"]) : var.rancher_server_url
+  ssh_private_key           = module.cluster_nodes.ssh_private_key
+  ssh_public_key            = module.cluster_nodes.ssh_public_key
+  deliverables_path         = var.deliverables_path
 
   rancher_password    = var.rancher_password
   create_user_cluster = var.rancher_create_user_cluster

--- a/terraform/vsphere-rancher/variables.tf
+++ b/terraform/vsphere-rancher/variables.tf
@@ -4,6 +4,12 @@ variable "cluster_node_count" {
   default     = 3
 }
 
+variable "cluster_master_node_count" {
+  type        = number
+  description = "Number of cluster master nodes"
+  default     = 3
+}
+
 variable "vsphere_user" {
   type        = string
   description = "VMware vSphere user name"


### PR DESCRIPTION
This change adds support to: 
 - Allow add more worker nodes
 - Fix issue when create cluster with the even number of nodes.